### PR TITLE
Downgrade minimum version to align with other ce projects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyHamcrest>=1.9.0
-boto3>=1.16.8
-botocore>=1.19.8
+boto3>=1.10.35
+botocore>=1.13.35

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     zip_safe=False,
     install_requires=['PyHamcrest>=1.9.0',
-                      'boto3>=1.16.8',
-                      'botocore>=1.19.8']
+                      'boto3>=1.10.35',
+                      'botocore>=1.13.35']
 )


### PR DESCRIPTION
To avoid warnings where other projects user versions of boto3 and botocore lower than the previous min versions, these versions have been downgraded as there is no issue running stack matchers with older versions. 